### PR TITLE
Bugfix#6

### DIFF
--- a/args2arr
+++ b/args2arr
@@ -161,8 +161,6 @@ EOF
 # Call the main function to parse all command line arguments
 parseArgs "$@"
 
-echo -e "arg:\n${arg[@]}"
-
 # Check if any errors were found
 # the function itself won't output anything or exit
 if [ $errCount -gt 0 ]; then

--- a/args2arr
+++ b/args2arr
@@ -27,15 +27,18 @@ parseArgs(){
         if [ "${currentArg:0:2}" != "--" ]; then
           split=1
           unaltered=$currentArg
-          currentArg=${currentArg/=/ }
-          currentArg=${currentArg:0:-2}
-          currentArg=${currentArg/ /}
           nextArg=${unaltered:$(( eqpos + 1 ))}
+          trim=${#nextArg}
+          currentArg=${currentArg/=/ }
+          currentArg=${currentArg:0:-$(( trim + 1 ))}
+          currentArg=${currentArg/ /}
         elif [ "${currentArg:0:2}" == "--" ]; then
           split=1
           unaltered=$currentArg
+          nextArg=${unaltered:$(( eqpos + 1 ))}
+          trim=${#nextArg}
           currentArg=${currentArg/=/ }
-          currentArg=${currentArg:0:-2}
+          currentArg=${currentArg:0:-$(( trim + 1 ))}
           currentArg=${currentArg/ /}
           nextArg=${unaltered:$(( $eqpos + 1 ))}
         fi
@@ -158,6 +161,8 @@ EOF
 # Call the main function to parse all command line arguments
 parseArgs "$@"
 
+echo -e "arg:\n${arg[@]}"
+
 # Check if any errors were found
 # the function itself won't output anything or exit
 if [ $errCount -gt 0 ]; then
@@ -201,6 +206,16 @@ seqq(){
 # Combine the 2 arrays into an associative array
 # Note: can't be done in the function as 'declare' is needed
 # and makes the array local to the function
+#
+# *** IMPORTANT ***
+#
+# This does NOT cater for duplicate parameters:
+#   -a=first -a=second
+# will result in a=second
+#
+# see https://github.com/davejbarnes/random/issues/7
+# for details of how to handle duplicates 
+#
 declare -A argArr
 for i in $(seqq 1 $numArgs); do
   argArr[${arg[$i]}]=${value[$i]}


### PR DESCRIPTION
fixes https://github.com/davejbarnes/random/issues/6

parameters using the '`-a=123`' or '`--param=123`' would not be interrupted correctly
where '`a=1`' and '`--param=1`' would be interrupted correctly

Updated to trim the string based on the length of the value, rather than assuming length is 1
Doh!